### PR TITLE
chore: add endpoint for getting data required for status page

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@supabase/supabase-js": "^1.30.3",
     "@types/passport-jwt": "^3.0.6",
     "apollo-server-express": "^2",
+    "date-fns": "^2.28.0",
     "graphql": "15.7.2",
     "graphql-scalars": "^1.14.1",
     "graphql-tools": "^8.2.0",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -159,6 +159,7 @@ export interface IQuery {
     incidentRoomURL(id: string): Nullable<string> | Promise<Nullable<string>>;
     organizations(): Nullable<Organization>[] | Promise<Nullable<Organization>[]>;
     organization(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;
+    organizationStatus(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;
     serviceGroups(): Nullable<ServiceGroup>[] | Promise<Nullable<ServiceGroup>[]>;
     serviceGroup(id: string): Nullable<ServiceGroup> | Promise<Nullable<ServiceGroup>>;
     services(): Nullable<Service>[] | Promise<Nullable<Service>[]>;

--- a/src/organizations/organizations.graphql
+++ b/src/organizations/organizations.graphql
@@ -21,6 +21,7 @@ input UpdateOrganizationInput {
 type Query {
   organizations: [Organization]!
   organization(id: ID!): Organization
+  organizationStatus(id: ID!): Organization
 }
 
 type Mutation {

--- a/src/organizations/organizations.resolver.ts
+++ b/src/organizations/organizations.resolver.ts
@@ -1,14 +1,21 @@
-import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
 
 import { OrganizationsService } from './organizations.service';
 import { CreateOrganizationInput, UpdateOrganizationInput } from '../graphql';
 
 import { User } from '@prisma/client';
 import { CurrentUser } from '../auth/current-user.decorator';
+import { Public } from 'src/auth/public.decorator';
 
 @Resolver('Organization')
 export class OrganizationsResolver {
   constructor(private readonly organizationsService: OrganizationsService) {}
+
+  @Public()
+  @Query('organizationStatus')
+  organizationStatus(@Args('id') id: string) {
+    return this.organizationsService.status(id);
+  }
 
   @Mutation('createOrganization')
   create(

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { sub } from 'date-fns';
 
 import { Organization, User } from '@prisma/client';
 import { permissionGuard } from '../auth/permission.guard';
@@ -8,6 +9,23 @@ import { UpdateOrganizationInput, CreateOrganizationInput } from '../graphql';
 @Injectable()
 export class OrganizationsService {
   constructor(private readonly db: DatabaseService) {}
+
+  async status(id: string): Promise<Organization> {
+    // Get the organization, all of its services
+    // and 60 days worth of incidents
+    return await this.db.organization.findUnique({
+      where: { id },
+      include: {
+        services: {
+          include: {
+            incidents: {
+              where: { incidentDate: { gte: sub(new Date(), { days: 60 }) } },
+            },
+          },
+        },
+      },
+    });
+  }
 
   async create(
     createOrganizationInput: CreateOrganizationInput,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,6 +2801,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 debug@2.6.9, debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
### tl;dr

- [x] Adds `organizationStatus` query that returns data required for an organization's status page