### PR TITLE
feat: add query to get incident by assignedID and by service id

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -155,8 +155,9 @@ export interface IQuery {
     eventsByIncidentId(incidentId: string): Nullable<Nullable<Event>[]> | Promise<Nullable<Nullable<Event>[]>>;
     incidents(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     incident(id: string): Nullable<Incident> | Promise<Nullable<Incident>>;
-    incidentsByOrganizationId(orgId: string): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
+    incidentsByServiceId(serviceId: string): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     incidentRoomURL(id: string): Nullable<string> | Promise<Nullable<string>>;
+    incidentsByAssignedId(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     organizations(): Nullable<Organization>[] | Promise<Nullable<Organization>[]>;
     organization(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;
     organizationStatus(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -158,6 +158,7 @@ export interface IQuery {
     incidentsByServiceId(serviceId: string): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     incidentRoomURL(id: string): Nullable<string> | Promise<Nullable<string>>;
     incidentsByAssignedId(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
+    openIncidents(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     organizations(): Nullable<Organization>[] | Promise<Nullable<Organization>[]>;
     organization(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;
     organizationStatus(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -157,7 +157,7 @@ export interface IQuery {
     incident(id: string): Nullable<Incident> | Promise<Nullable<Incident>>;
     incidentsByServiceId(serviceId: string): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     incidentRoomURL(id: string): Nullable<string> | Promise<Nullable<string>>;
-    incidentsByAssignedId(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
+    assignedIncidents(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     openIncidents(): Nullable<Incident>[] | Promise<Nullable<Incident>[]>;
     organizations(): Nullable<Organization>[] | Promise<Nullable<Organization>[]>;
     organization(id: string): Nullable<Organization> | Promise<Nullable<Organization>>;

--- a/src/incidents/incidents.graphql
+++ b/src/incidents/incidents.graphql
@@ -56,6 +56,7 @@ type Query {
   incidentsByServiceId(serviceId: ID!): [Incident]!
   incidentRoomURL(id: ID!): String
   incidentsByAssignedId: [Incident]!
+  openIncidents: [Incidents]!
 }
 
 type Mutation {

--- a/src/incidents/incidents.graphql
+++ b/src/incidents/incidents.graphql
@@ -53,8 +53,9 @@ input UpdateIncidentInput {
 type Query {
   incidents: [Incident]!
   incident(id: ID!): Incident
-  incidentsByOrganizationId(orgId: ID!): [Incident]!
+  incidentsByServiceId(serviceId: ID!): [Incident]!
   incidentRoomURL(id: ID!): String
+  incidentsByAssignedId: [Incident]!
 }
 
 type Mutation {

--- a/src/incidents/incidents.graphql
+++ b/src/incidents/incidents.graphql
@@ -55,7 +55,7 @@ type Query {
   incident(id: ID!): Incident
   incidentsByServiceId(serviceId: ID!): [Incident]!
   incidentRoomURL(id: ID!): String
-  incidentsByAssignedId: [Incident]!
+  assignedIncidents: [Incident]!
   openIncidents: [Incident]!
 }
 

--- a/src/incidents/incidents.graphql
+++ b/src/incidents/incidents.graphql
@@ -56,7 +56,7 @@ type Query {
   incidentsByServiceId(serviceId: ID!): [Incident]!
   incidentRoomURL(id: ID!): String
   incidentsByAssignedId: [Incident]!
-  openIncidents: [Incidents]!
+  openIncidents: [Incident]!
 }
 
 type Mutation {

--- a/src/incidents/incidents.resolver.ts
+++ b/src/incidents/incidents.resolver.ts
@@ -32,6 +32,16 @@ export class IncidentsResolver {
     return this.incidentsService.findRoomURL(id, user);
   }
 
+  @Query('incidentsByServiceId')
+  incidentsByServiceId(id: string) {
+    return this.incidentsService.findAllByServiceId(id);
+  }
+
+  @Query('incidentsByAssignedId')
+  incidentsByAssignedId(@CurrentUser() user: User) {
+    return this.incidentsService.findAllByAssignedId(user);
+  }
+
   @Mutation('updateIncident')
   update(
     @Args('updateIncidentInput') updateIncidentInput: UpdateIncidentInput,

--- a/src/incidents/incidents.resolver.ts
+++ b/src/incidents/incidents.resolver.ts
@@ -37,9 +37,9 @@ export class IncidentsResolver {
     return this.incidentsService.findAllByServiceId(serviceId);
   }
 
-  @Query('incidentsByAssignedId')
-  incidentsByAssignedId(@CurrentUser() user: User) {
-    return this.incidentsService.findAllByAssignedId(user);
+  @Query('assignedIncidents')
+  assignedIncidents(@CurrentUser() user: User) {
+    return this.incidentsService.findAllByAssignedIncidents(user);
   }
 
   @Query('openIncidents')

--- a/src/incidents/incidents.resolver.ts
+++ b/src/incidents/incidents.resolver.ts
@@ -42,6 +42,11 @@ export class IncidentsResolver {
     return this.incidentsService.findAllByAssignedId(user);
   }
 
+  @Query('openIncidents')
+  openIncidents(@CurrentUser() user: User) {
+    return this.incidentsService.findAllOpenIncidents(user);
+  }
+
   @Mutation('updateIncident')
   update(
     @Args('updateIncidentInput') updateIncidentInput: UpdateIncidentInput,

--- a/src/incidents/incidents.resolver.ts
+++ b/src/incidents/incidents.resolver.ts
@@ -33,8 +33,8 @@ export class IncidentsResolver {
   }
 
   @Query('incidentsByServiceId')
-  incidentsByServiceId(id: string) {
-    return this.incidentsService.findAllByServiceId(id);
+  incidentsByServiceId(@Args('serviceId') serviceId: string) {
+    return this.incidentsService.findAllByServiceId(serviceId);
   }
 
   @Query('incidentsByAssignedId')

--- a/src/incidents/incidents.service.ts
+++ b/src/incidents/incidents.service.ts
@@ -7,7 +7,6 @@ import { Incident, User, IncidentStatus } from '@prisma/client';
 import { permissionGuard } from '../auth/permission.guard';
 import { DatabaseService } from '../database/database.service';
 import { CreateIncidentInput, UpdateIncidentInput } from '../graphql';
-import { STATUS_CODES } from 'http';
 
 @Injectable()
 export class IncidentsService {
@@ -108,7 +107,7 @@ export class IncidentsService {
     });
   }
 
-  async findAllByAssignedId(user: User): Promise<Incident[]> {
+  async findAllByAssignedIncidents(user: User): Promise<Incident[]> {
     return await this.db.incident.findMany({
       where: { assigneeId: user.id },
     });

--- a/src/incidents/incidents.service.ts
+++ b/src/incidents/incidents.service.ts
@@ -3,10 +3,11 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { map, lastValueFrom } from 'rxjs';
 
-import { Incident, User } from '@prisma/client';
+import { Incident, User, IncidentStatus } from '@prisma/client';
 import { permissionGuard } from '../auth/permission.guard';
 import { DatabaseService } from '../database/database.service';
 import { CreateIncidentInput, UpdateIncidentInput } from '../graphql';
+import { STATUS_CODES } from 'http';
 
 @Injectable()
 export class IncidentsService {
@@ -110,6 +111,17 @@ export class IncidentsService {
   async findAllByAssignedId(user: User): Promise<Incident[]> {
     return await this.db.incident.findMany({
       where: { assigneeId: user.id },
+    });
+  }
+
+  async findAllOpenIncidents(user: User): Promise<Incident[]> {
+    return await this.db.incident.findMany({
+      where: {
+        organizationId: user.organizationId,
+        NOT: {
+          status: IncidentStatus.RESOLVED,
+        },
+      },
     });
   }
 

--- a/src/incidents/incidents.service.ts
+++ b/src/incidents/incidents.service.ts
@@ -101,6 +101,18 @@ export class IncidentsService {
     return roomURL;
   }
 
+  async findAllByServiceId(id: string): Promise<Incident[]> {
+    return await this.db.incident.findMany({
+      where: { service: { id } },
+    });
+  }
+
+  async findAllByAssignedId(user: User): Promise<Incident[]> {
+    return await this.db.incident.findMany({
+      where: { assigneeId: user.id },
+    });
+  }
+
   async update(
     updateIncidentInput: UpdateIncidentInput,
     user: User,

--- a/src/incidents/incidents.service.ts
+++ b/src/incidents/incidents.service.ts
@@ -104,7 +104,7 @@ export class IncidentsService {
 
   async findAllByServiceId(id: string): Promise<Incident[]> {
     return await this.db.incident.findMany({
-      where: { service: { id } },
+      where: { serviceId: id },
     });
   }
 


### PR DESCRIPTION
This PR:

- [x] Add queries: ` incidentsByServiceId(serviceId: ID!)` , ` incidentsByAssignedId`, and ` openIncidents`
- [x] Closes #10 #8 